### PR TITLE
pc - refactor pages to have Page as suffix of name and add them to storybook

### DIFF
--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -4,8 +4,8 @@ import AppNavbar from "main/components/Nav/AppNavbar";
 import { Container } from "react-bootstrap";
 import { Route, Switch } from "react-router-dom";
 import AppFooter from "main/components/Footer/AppFooter";
-import About from "main/pages/About/About";
-import Home from "main/pages/Home/Home";
+import AboutPage from "main/pages/AboutPage";
+import HomePage from "main/pages/HomePage";
 
 function App() {
   return (
@@ -13,8 +13,8 @@ function App() {
       <AppNavbar />
       <Container className="flex-grow-1 mt-5">
         <Switch>
-          <Route path="/" exact component={Home} />
-          <Route path="/about" component={About} />
+          <Route path="/" exact component={HomePage} />
+          <Route path="/about" component={AboutPage} />
         </Switch>
       </Container>
       <AppFooter />

--- a/javascript/src/main/pages/AboutPage.js
+++ b/javascript/src/main/pages/AboutPage.js
@@ -11,7 +11,10 @@ const About = () => {
           base created initially with Create React App, and then customized for
           use in CMPSC 156 at UCSB.
         </p>
-        <p>This repo is similar to t</p>
+        <p>
+          This repo can be used as a base for creating apps that have only a
+          React front end, and require no backend code.
+        </p>
         <p>Some tools used to create this app:</p>
         <ul>
           <li>

--- a/javascript/src/main/pages/HomePage.js
+++ b/javascript/src/main/pages/HomePage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Jumbotron } from "react-bootstrap";
 
-const Home = () => {
+const HomePage = () => {
   return (
     <Jumbotron>
       <div className="text-left">
@@ -12,4 +12,4 @@ const Home = () => {
   );
 };
 
-export default Home;
+export default HomePage;

--- a/javascript/src/stories/pages/AboutPage.stories.js
+++ b/javascript/src/stories/pages/AboutPage.stories.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import AboutPage from "main/pages/AboutPage";
+
+export default {
+  title: "pages/AboutPage",
+  component: AboutPage,
+};
+
+const Template = () => (
+  <MemoryRouter>
+    <AboutPage />
+  </MemoryRouter>
+);
+
+export const Default = Template.bind({});

--- a/javascript/src/stories/pages/HomePage.stories.js
+++ b/javascript/src/stories/pages/HomePage.stories.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import HomePage from "main/pages/HomePage";
+
+export default {
+  title: "pages/HomePage",
+  component: HomePage,
+};
+
+const Template = () => (
+  <MemoryRouter>
+    <HomePage />
+  </MemoryRouter>
+);
+
+export const Default = Template.bind({});

--- a/javascript/src/test/pages/AboutPage.test.js
+++ b/javascript/src/test/pages/AboutPage.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import Home from "main/pages/Home/Home";
+import AboutPage from "main/pages/AboutPage";
 
-describe("Home tests", () => {
+describe("About tests", () => {
   test("renders without crashing", () => {
-    render(<Home/>);
+    render(<AboutPage />);
   });
 });

--- a/javascript/src/test/pages/HomePage.test.js
+++ b/javascript/src/test/pages/HomePage.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import About from "main/pages/About/About";
+import HomePage from "main/pages/HomePage";
 
-describe("About tests", () => {
+describe("HomePage tests", () => {
   test("renders without crashing", () => {
-    render(<About />);
+    render(<HomePage />);
   });
 });


### PR DESCRIPTION
In this PR, we refactor the React components that represent pages to each have `Page` as the suffix of their names (for clarity), and we add them to the Storybook.

This PR is also, indirectly, a means of testing whether the GitHub Action we set up that is supposed to update the QA storybook on pull requests is working properly.  If so, then two things should be true:

- [ ] We see these storybook changes reflected in the QA Storybook repo  <https://ucsb-cs156-s21.github.io/demo-react-minimal-docs-qa/> immediately upon filing this pull request (or at least, immediately after the GitHub action to build the QA storybook is done running).
- [ ] We should not yet see these changes in the Main storybook repo here: <https://ucsb-cs156-s21.github.io/demo-react-minimal-docs/>, but we will see those when and if this PR is merged into main.